### PR TITLE
FHD以上の解像度でトップの画像表示が崩れる問題を修正

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -24,9 +24,10 @@
   position: absolute;
   top: 0;
   right: 0;
-  width: auto;
+  width: 100%;
   height: 600px;
   object-fit: cover;
+  object-position: right;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/Hero/index.module.css
+++ b/components/Hero/index.module.css
@@ -45,7 +45,9 @@
   top: 0;
   right: 0;
   height: 600px;
-  width: auto;
+  width: 100%;
+  object-fit: cover;
+  object-position: right;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## 発生原因

表示エリアが画像アスペクト比を超えた場合 `width: auto;` のため高さに依存して幅が固定されてしまう。

## 修正意図

`width: 100%;` とすることで表示エリアを使えるようにする。
そのままだと幅が狭いときに画像の左右が見切れてしまうため左側だけ見切れるように `object-position: right;` を追加して調整

## 変更箇所

- /app/page.module.css
- /components/Hero/index.module.css



before

![image](https://github.com/microcmsio/nextjs-simple-corporate-site-template/assets/8376036/5648d6f3-5d61-460b-8153-d5a1d7c056cb)


after

![image](https://github.com/microcmsio/nextjs-simple-corporate-site-template/assets/8376036/6b6872c4-417d-41a6-b7b9-a5ca92f36ba1)
