### PR TITLE
Update category component

### DIFF
--- a/app/_components/Category/index.tsx
+++ b/app/_components/Category/index.tsx
@@ -2,9 +2,12 @@ import type { Category } from '@/app/_libs/microcms';
 import styles from './index.module.css';
 
 type Props = {
-  category: Category;
+  category?: Category;
 };
 
 export default function Category({ category }: Props) {
+  if (!category) {
+    return null;
+  }
   return <span className={styles.tag}>{category.name}</span>;
 }


### PR DESCRIPTION
### 解消したい内容
NewsのAPIスキーマでカテゴリが任意項目だがコンポーネント側の型だと必須なので、カテゴリの入力がないとフロント側でエラーになる

### 対応内容
コンポーネント側のprops の `category` の型をオプショナルにしました
本来は必須の想定だった場合は、APIスキーマを修正してこのPRは破棄してください