### PR TITLE
ヒーローイメージに priority を設定する

### DIFF
--- a/app/_components/Hero/index.tsx
+++ b/app/_components/Hero/index.tsx
@@ -13,7 +13,14 @@ export default function Hero({ title, sub }: Props) {
         <h1 className={styles.title}>{title}</h1>
         <p className={styles.sub}>{sub}</p>
       </div>
-      <Image className={styles.bgimg} src="/img-mv.jpg" alt="" width={4000} height={1200} />
+      <Image
+        className={styles.bgimg}
+        src="/img-mv.jpg"
+        alt=""
+        width={4000}
+        height={1200}
+        priority
+      />
     </section>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,14 @@ export default async function Page() {
             私たちは市場をリードしているグローバルテックカンパニーです。
           </p>
         </div>
-        <Image className={styles.bgimg} src="/img-mv.jpg" alt="" width={3600} height={1200} />
+        <Image
+          className={styles.bgimg}
+          src="/img-mv.jpg"
+          alt=""
+          width={3600}
+          height={1200}
+          priority
+        />
       </section>
       <section className={styles.news}>
         <h2 className={styles.newsTitle}>News</h2>


### PR DESCRIPTION
デフォルトのままだと `img` に `loading="lazy"` が設定されてしまい LCP に影響が出る可能性があるため、各ページのヒーローイメージに [`priority`](https://nextjs.org/docs/app/api-reference/components/image#priority) を設定しました。

（microCMS の学習用にこちらのテンプレートを使わせていただき、非常に参考になりました。ありがとうございました）