### PR TITLE
[fix] cheerioの不要なタグ挿入を除去、@types/cheerioを削除

### DIFF
--- a/app/_libs/utils.ts
+++ b/app/_libs/utils.ts
@@ -8,7 +8,7 @@ export const formatDate = (date: string) => {
 };
 
 export const formatRichText = (richText: string) => {
-  const $ = load(richText);
+  const $ = load(richText, null, false);
   $('pre code').each((_, elm) => {
     const lang = $(elm).attr('class');
     const res = lang

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "nextjs-simple-corporate-site-template",
       "version": "0.1.0",
       "dependencies": {
-        "@types/cheerio": "^0.22.35",
         "@types/node": "^22.13.10",
         "@types/react": "^19.0.11",
         "@types/react-dom": "^19.0.4",
@@ -463,15 +462,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@types/cheerio": {
-      "version": "0.22.35",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
-      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">=18.x"
   },
   "dependencies": {
-    "@types/cheerio": "^0.22.35",
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.11",
     "@types/react-dom": "^19.0.4",


### PR DESCRIPTION
- cheerioでhtml/body/headタグが挿入されないように修正
  - `load(richText, null, false)` に変更
  - 参考：https://github.com/cheeriojs/cheerio/blob/b7a0f2c0211c056c2cca6a5ea137dd181b969cb5/src/load-parse.ts#L16-L23
- `@types/cheerio`の削除